### PR TITLE
hotfix with thumbnails - move to filesystem and drop base64 encoded s…

### DIFF
--- a/archive/admin.py
+++ b/archive/admin.py
@@ -78,17 +78,20 @@ class ImageAdmin(admin.ModelAdmin):
 
   @admin.action(description='Reset thumbnails')
   def reset_thumbnail(modeladmin, request, queryset):
-    queryset.update(thumbnail=None)
+    # queryset.update(thumbnail=None)
+    for object in queryset:
+      object.thumbnail = None
+      object.save()
   
-  @admin.action(description='Reset Image Dimensions')
-  def resetDimensions(modeladmin, request, queryset):
-    for image in queryset:
-      image.storeDimensions()
-  @admin.action(description='Reset Image Orientation')
-  def resetOrientation(modeladmin, request, queryset):
-    for image in queryset:
-      image.storeOrientation()
-  @admin.action(description='Reset File Size')
+  # @admin.action(description='Reset Image Dimensions')
+  # def resetDimensions(modeladmin, request, queryset):
+  #   for image in queryset:
+  #     image.storeDimensions()
+  # @admin.action(description='Reset Image Orientation')
+  # def resetOrientation(modeladmin, request, queryset):
+  #   for image in queryset:
+  #     image.storeOrientation()
+  # @admin.action(description='Reset File Size')
   def resetSize(modeladmin, request, queryset):
     for object in queryset:
       object.storeSize()
@@ -96,9 +99,9 @@ class ImageAdmin(admin.ModelAdmin):
 
   list_display = ['get_indexed_name', 'slug', 'show_in_index', 'year']
   search_fields = ['title', 'description']
-  exclude = ['thumbnail']
+  exclude = []
   empty_value_display = '---'
-  actions = [toggle_show, softdelete, softundelete, setSlugFromTitle, reset_thumbnail, resetDimensions, resetOrientation, resetSize,  ]
+  actions = [toggle_show, softdelete, softundelete, setSlugFromTitle, reset_thumbnail, resetSize,  ]
   list_filter = ['tag', 'show_in_index', 'people']
   def get_changeform_initial_data(self, request):
     get_data = super(ImageAdmin, self).get_changeform_initial_data(request)

--- a/archive/templates/archive/snippets/image.html
+++ b/archive/templates/archive/snippets/image.html
@@ -3,7 +3,7 @@
     <h2><span class="object-id">#{{ object.id }}</span><a href="{% url 'archive:image' object.slug %}" title="{{ object.title }}" tabindex="{{ forloop.counter }}">{{ object.title|truncatewords_html:3 }}</a></h2>
     <div class="column left">
       <a href="{% url 'archive:image' object.slug %}" title="{{ object.title }}">
-        <img src="{{ object.thumbnail }}" alt="{{ object.title }}" title="{{ object.title }} - {{ object.description }}">
+        <img src="/documents/{{ object.thumbnail }}" alt="{{ object.title }}" title="{{ object.title }} - {{ object.description }}">
       </a>
     </div>
     <div class="column right">


### PR DESCRIPTION
…torage in db

Generating thumbnails has failed somewhere in the works. This is a good moment to make the thumbnail generation work better by moving it to the filesystem storage