### PR TITLE
fixed bug empty page after login #264 by showing content when logged in

### DIFF
--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,4 +1,4 @@
-{% extends "index.html" %}
+{% extends "index.html" %}{% load i18n %}
 
 {% block pagetitle %}Aanmelden{% endblock %}
 
@@ -14,4 +14,12 @@
     </form>
     <p class="text-center">Heb je nog geen account, <a href="{% url 'archive:signup' %}">registreer</a> je hier.</p>
   </div>
+{% endblock %}
+
+{% block content %}
+  {% if user.is_authenticated %}
+    <div class="message">
+        {% translate "you have succesfully logged in"|capfirst %}. <a href="/">{% translate 'click here'|capfirst %}</a> {% translate 'to go to the homepage' %}.
+    </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Added content block to login page for logged in users, so now a message that login was succesfull will be shown.
Closes 264