### PR TITLE
bugfix when listing all comments

### DIFF
--- a/archive/views/aComment.py
+++ b/archive/views/aComment.py
@@ -66,7 +66,7 @@ class aListComments(ListView):
         'error': True,
         'message': _('comments cannot be loaded').capitalize(),
       })
-    if object.count_comments() > 0:
+    if object and object.count_comments() > 0:
       response['payload'].append(render_to_string('archive/partial/commentcounter.html', {'image': object, }))
     for comment in comments:
       response['payload'].append(render_to_string('archive/partial/comment.html', {'comment': comment, 'show_thumbnail': show_thumbnail, 'user':self.request.user }))


### PR DESCRIPTION
to add the comment counter, a check was added if the counter was. >0. But this doesnt work when there is no object, so all comments are listed.